### PR TITLE
Requires 8.3 to support spread operator out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Node.js interface for [Telldus Live API](http://api.telldus.com/) and [Telldus Local API](https://developer.telldus.com/blog/2016/05/24/local-api-for-tellstick-znet-lite-beta-now-in-public-beta). Since their APIs are similar, I added support for both. All API methods are promise based. Both LiveApi and LocalApi inherit from the same class Api which has the same methods. However not all methods are implemented or make sense on LocalApi.
 
 ## Install
-⚠️ Requires node 8
+⚠️ Requires node 8.3 or greater.
 ```
 npm install telldus-api
 ```


### PR DESCRIPTION
Got an issue with 8.1 since I wasn't using the harmony flags on the Spread Operator. Supported out of the box with 8.3